### PR TITLE
timesheet_workitems

### DIFF
--- a/src/com/ppm/integration/agilesdk/connector/agilecentral/model/Backlog.java
+++ b/src/com/ppm/integration/agilesdk/connector/agilecentral/model/Backlog.java
@@ -1,0 +1,100 @@
+package com.ppm.integration.agilesdk.connector.agilecentral.model;
+
+import java.util.Date;
+
+import net.sf.json.JSONObject;
+
+import com.ppm.integration.agilesdk.pm.ExternalTask;
+import com.ppm.integration.agilesdk.provider.UserProvider;
+
+public class Backlog extends Entity {
+
+	private Iteration iteration;
+	private User user;
+	private final UserProvider userProvider;
+
+	public Backlog(JSONObject jsonObject, UserProvider userProvider) {
+		super(jsonObject);
+		this.userProvider = userProvider;
+	}
+
+	public String getIterationUUID() {
+		JSONObject iteration = this.jsonObject.getJSONObject("Iteration");
+		if (!iteration.isNullObject()) {
+			return iteration.getString("_refObjectUUID");
+		}
+		return null;
+	}
+	
+	public String getProjectUUID() {
+		JSONObject project = this.jsonObject.getJSONObject("Project");
+		if (!project.isNullObject()) {
+			return project.getString("_refObjectUUID");
+		}
+		return null;
+	}
+	
+	public String getOwnerUUID() {
+		JSONObject iteration = this.jsonObject.getJSONObject("Owner");
+		if (!iteration.isNullObject()) {
+			return iteration.getString("_refObjectUUID");
+		}
+		return null;
+	}
+
+	public void setIteration(Iteration iteration) {
+		this.iteration = iteration;
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	public Date getScheduleStart() {
+		return iteration.getScheduleStart();
+	}
+
+	public Date getScheduleFinish() {
+		return iteration.getScheduleFinish();
+	}
+
+	@Override
+	public long getOwnerId() {
+		com.hp.ppm.user.model.User u = userProvider.getByEmail(this.user.getEmailAddress());
+		return u == null ? -1 : u.getUserId();
+	}
+
+	@Override
+	public String getOwnerRole() {		
+		//change
+		return this.user == null ? null : this.user.getRole();
+	}
+
+	@Override
+	public TaskStatus getStatus() {
+		String state = (check("ScheduleState") ? jsonObject.getString("ScheduleState") : null);
+        ExternalTask.TaskStatus result = ExternalTask.TaskStatus.UNKNOWN;
+		//Defined,In-Progress,Completed,Accepted
+		switch (state){
+		case "Defined":
+                result = ExternalTask.TaskStatus.READY;
+			break;
+		case "In-Progress":
+                result = ExternalTask.TaskStatus.IN_PROGRESS;
+			break;
+		case "Completed":
+		case "Accepted":
+                result = ExternalTask.TaskStatus.COMPLETED;
+			break;
+		}
+		return result;
+	}
+	
+    public int getChildrenCount() {
+        JSONObject tasks = this.jsonObject.getJSONObject("Children");
+        if (!tasks.isNullObject()) {
+            return tasks.getInt("Count");
+        }
+        return 0;
+    }
+}

--- a/src/com/ppm/integration/agilesdk/connector/agilecentral/model/Defect.java
+++ b/src/com/ppm/integration/agilesdk/connector/agilecentral/model/Defect.java
@@ -4,9 +4,10 @@ import net.sf.json.JSONObject;
 
 import com.ppm.integration.agilesdk.provider.UserProvider;
 
-public class HierarchicalRequirement extends Backlog {
+public class Defect extends Backlog {
 
-    public HierarchicalRequirement(JSONObject jsonObject, UserProvider userProvider) {
+    public Defect(JSONObject jsonObject, UserProvider userProvider) {
         super(jsonObject, userProvider);
     }
+	
 }

--- a/src/com/ppm/integration/agilesdk/connector/agilecentral/model/Testset.java
+++ b/src/com/ppm/integration/agilesdk/connector/agilecentral/model/Testset.java
@@ -4,9 +4,10 @@ import net.sf.json.JSONObject;
 
 import com.ppm.integration.agilesdk.provider.UserProvider;
 
-public class HierarchicalRequirement extends Backlog {
+public class Testset extends Backlog {
 
-    public HierarchicalRequirement(JSONObject jsonObject, UserProvider userProvider) {
+    public Testset(JSONObject jsonObject, UserProvider userProvider) {
         super(jsonObject, userProvider);
     }
+	
 }

--- a/src/com/ppm/integration/agilesdk/connector/agilecentral/model/TimeEntryItem.java
+++ b/src/com/ppm/integration/agilesdk/connector/agilecentral/model/TimeEntryItem.java
@@ -16,4 +16,11 @@ public class TimeEntryItem extends Entity {
         return null;
     }
 
+    public String getWorkProductUUID() {
+        JSONObject iteration = this.jsonObject.getJSONObject("WorkProduct");
+        if (!iteration.isNullObject()) {
+            return iteration.getString("_refObjectUUID");
+        }
+        return null;
+    }
 }

--- a/src/com/ppm/integration/agilesdk/connector/agilecentral/model/TimeEntryValue.java
+++ b/src/com/ppm/integration/agilesdk/connector/agilecentral/model/TimeEntryValue.java
@@ -1,8 +1,8 @@
 package com.ppm.integration.agilesdk.connector.agilecentral.model;
 
-import net.sf.json.JSONObject;
-
 import java.util.Date;
+
+import net.sf.json.JSONObject;
 
 public class TimeEntryValue extends Entity {
 
@@ -18,8 +18,7 @@ public class TimeEntryValue extends Entity {
         return check("Hours") ? jsonObject.getInt("Hours") : 0;
     }
 
-    // add
-    public String getItemUUID() {
+    public String getTimeEntryItemUUID() {
         JSONObject iteration = this.jsonObject.getJSONObject("TimeEntryItem");
         if (!iteration.isNullObject()) {
             return iteration.getString("_refObjectUUID");


### PR DESCRIPTION
(1) Label: ”User Story” change to “Work Item”
(2) Timesheet: remove “task” level of data display detail level.
(3) Timesheet: modify defect about the process to get the “time spent”
values.
(4) In work Item part of rally, there are seven types of data, they are
user story (“US”), defect (“DE”), defect suite (“DS”, a bundle of
defects, not include in work item or iteration of timesheet), task
(“TA”, only can be included by defects or user story), Test Case (“TC”),
Test Case Results and Portfolio items (ignore). Therefore, I add the
“defect” and “testset” (“TS”, a collection of test cases) to the
timesheet.